### PR TITLE
Introduce better way of handling exceptions from CRUD Services

### DIFF
--- a/lib/nifty_services/base_crud_service.rb
+++ b/lib/nifty_services/base_crud_service.rb
@@ -76,5 +76,9 @@ module NiftyServices
     def valid_record?
       valid_object?(@record, record_type)
     end
+
+    def raise_record_error_exception(method_name, error)
+      raise error, "You must implement #{method_name} in your class(#{self.class}) to handle exceptions"
+    end
   end
 end

--- a/lib/nifty_services/base_service.rb
+++ b/lib/nifty_services/base_service.rb
@@ -32,6 +32,7 @@ module NiftyServices
       alias_method :include_concern, :concern
     end
 
+    public
     def initialize(options = {}, initial_response_status = 400)
       @options = with_default_options(options)
       @errors = []
@@ -94,6 +95,7 @@ module NiftyServices
     alias :runned? :executed?
 
     private
+
     def with_default_options(options)
       default_options.merge(options).symbolize_keys
     end
@@ -194,8 +196,8 @@ module NiftyServices
 
       return changes if old.nil? || current.nil?
 
-      old_attributes = old.attributes.slice(*attributes.map(&:to_s))
-      new_attributes = current.attributes.slice(*attributes.map(&:to_s))
+      old_attributes = old.attributes.symbolize_keys.slice(*attributes.map(&:to_sym))
+      new_attributes = current.attributes.symbolize_keys.slice(*attributes.map(&:to_sym))
 
       new_attributes.each do |attribute, value|
         changes << attribute if (old_attributes[attribute] != value)

--- a/lib/nifty_services/version.rb
+++ b/lib/nifty_services/version.rb
@@ -1,3 +1,3 @@
 module NiftyServices
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
This PR introduces methods to allow developers to handle the exceptions in the way they want, not making assumptions.

This PR also include `after_<action>_failed` methods which basically give developers freedom to do whatever they want when an CRUD action fail, ex: when record can't be saved due validation errors(but not exception was raised).

