### PR TITLE
Better strategy for object allocation

### DIFF
--- a/lib/nifty_services/base_service.rb
+++ b/lib/nifty_services/base_service.rb
@@ -40,6 +40,8 @@ module NiftyServices
 
       @executed = false
 
+      callbacks_setup
+
       with_before_and_after_callbacks(:initialize) do
         set_response_status(initial_response_status)
       end

--- a/lib/nifty_services/extensions/callbacks.rb
+++ b/lib/nifty_services/extensions/callbacks.rb
@@ -64,6 +64,8 @@ module NiftyServices
     def register_callback(callback_name, method_name, &block)
       method_name = normalized_callback_name(method_name).to_sym
 
+      @registered_callbacks[callback_name.to_sym] ||= []
+
       @registered_callbacks[callback_name.to_sym] << method_name
       register_callback_action(callback_name, &block)
     end
@@ -79,7 +81,7 @@ module NiftyServices
 
       @fired_callbacks, @custom_fired_callbacks = {}, {}
       @callbacks_actions = {}
-      @registered_callbacks ||= Hash.new {|k,v| k[v] = [] }
+      @registered_callbacks ||= {}
 
       @callbacks_setup = true
     end
@@ -121,6 +123,8 @@ module NiftyServices
 
     def instance_call_all_custom_registered_callbacks_for(callback_name)
       callbacks = @registered_callbacks[callback_name.to_sym]
+
+      return unless callbacks
 
       callbacks.each do |cb|
         if callback = @callbacks_actions[cb.to_sym]

--- a/lib/nifty_services/util.rb
+++ b/lib/nifty_services/util.rb
@@ -1,9 +1,11 @@
 module NiftyServices
   module Util
     def normalized_callback_name(callback_name, suffix = '_callback')
-      cb_name = callback_name.to_s.gsub(%r(\Z#{suffix}), '')
+      cb_name = callback_name.to_s.end_with?(suffix) ?
+                  callback_name.to_s.sub(/#{suffix}\Z/, '') :
+                  callback_name.to_s
 
-      [cb_name, suffix].join
+      cb_name << suffix
     end
     module_function :normalized_callback_name
   end

--- a/spec/base_service_spec.rb
+++ b/spec/base_service_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe NiftyServices::BaseService, type: :service do
 
   it 'must have error handle methods' do
     NiftyServices::Configuration.response_errors_list.each do |method, response_status|
-      expect(subject.respond_to?("#{method}_error", true)).to be_truthy
+      method_name = NiftyServices::Util.normalized_callback_name(method, '_error')
+      expect(subject.respond_to?(method_name, true)).to be_truthy
     end
   end
 


### PR DESCRIPTION
Before this patch, my application reported: `49260` objects allocation in one HTTP request, after searching why, I discovered that NiftyServices was doing unnecessary methods call, the one in `util.rb` was allocating almost `11k` objects trying to remove the suffix from string, no *gsub* is called only when is REALLY necessary, this solved the first problem.

The second one is related to callbacks,  removing the methods call to *empty callback methods*(that just return nil) skipped some processing, but marking callback as `fired` wihout cheking if callback method is implement solved another big issue.

Now, my HTTP request allocate `10702` objects, this is `38558` less objects. I believe that this subject still have job to be done. I will look more closer to `callbacks.rb` file and try to find anothers 
unnecessary objects allocation spots.

**Before:**
![Before](http://i.imgur.com/W1leWIK.png)

**After:**
![After](http://i.imgur.com/LqxDhgx.png)